### PR TITLE
sometimes callback is not called

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,11 @@ class BottomScrollListener extends Component {
   constructor(props) {
     super(props);
 
-    this.handleOnScroll = debounce(this.handleOnScroll.bind(this), props.debounce, { trailing: true });
+    if (props.debounce) {
+      this.handleOnScroll = debounce(this.handleOnScroll.bind(this), props.debounce, { trailing: true });
+    } else {
+      this.handleOnScroll = this.handleOnScroll.bind(this);
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
Hi @karl-run , thanks for useful component.
I'm using your component to implement the infinite scroll.

I found that the callback is not called sometimes even if `debounce` is set to 0(ms) or like 1(ms).

I'm not sure why callback is not invoked though,
but it works perfect if without using lodash.

So,  I made PR to skip lodash implementation if `debounce` is set to 0.
could you accept this ?

thank you.