### PR TITLE
Make "triggerOnNoScroll" not required

### DIFF
--- a/src/component/index.tsx
+++ b/src/component/index.tsx
@@ -26,7 +26,7 @@ export interface Props {
   /**
    * Triggers the onBottom callback when the page has no scrollbar, defaults to false
    */
-  triggerOnNoScroll: boolean
+  triggerOnNoScroll?: boolean
 
   /**
    *   Optional children to be rendered.


### PR DESCRIPTION
Since `triggerOnNoScroll` is a boolean value that has a default to `false`, it is not required to be specified. Currently, it is a required value.